### PR TITLE
Fix the link for gettingstartedwithdjango

### DIFF
--- a/public/django/_data.json
+++ b/public/django/_data.json
@@ -17,7 +17,7 @@
         "lang": "EN",
         "publish": true,
         "published_at": "20150225",
-        "url": "http://gettingstartedwithdjango.com/en/lessons/introduction-and-launch/"
+        "url": "http://www.gettingstartedwithdjango.com/introduction-and-launch.html"
       },
       {
         "title": "Django Girls Tutorial",


### PR DESCRIPTION
Fixed the link, since it apparently requires www (the bare url doesn't work) and the actual link has changed